### PR TITLE
feat: added topic data source

### DIFF
--- a/rhoas/provider.go
+++ b/rhoas/provider.go
@@ -58,6 +58,7 @@ func Provider() *schema.Provider {
 			"rhoas_cloud_provider_regions": cloudproviders.DataSourceCloudProviderRegions(),
 			"rhoas_kafkas":                 kafkas.DataSourceKafkas(),
 			"rhoas_kafka":                  kafkas.DataSourceKafka(),
+			"rhoas_topic":                  topics.DataSourceTopic(),
 			"rhoas_service_accounts":       serviceaccounts.DataSourceServiceAccounts(),
 		},
 		ConfigureContextFunc: providerConfigure,

--- a/rhoas/topics/datasource_topic.go
+++ b/rhoas/topics/datasource_topic.go
@@ -1,0 +1,77 @@
+package topics
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	rhoasAPI "redhat.com/rhoas/rhoas-terraform-provider/m/rhoas/api"
+	"redhat.com/rhoas/rhoas-terraform-provider/m/rhoas/utils"
+)
+
+func DataSourceTopic() *schema.Resource {
+	return &schema.Resource{
+		Description: "`rhoas_topic` provides a Topic accessible to your organization in Red Hat OpenShift Streams for Apache Kafka.",
+		ReadContext: dataSourceTopicRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "The name of the Kafka topic",
+			},
+			"partitions": {
+				Description: "The number of partitions in the topic",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+			"kafka_id": {
+				Description: "The unique identifier for the Kafka instance",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+		},
+	}
+}
+
+func dataSourceTopicRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+
+	var diags diag.Diagnostics
+
+	api, ok := m.(rhoasAPI.Clients)
+	if !ok {
+		return diag.Errorf("unable to cast %v to rhoasAPI.Clients)", m)
+	}
+
+	val := d.Get("kafka_id")
+	kafkaID, ok := val.(string)
+	if !ok {
+		return diag.Errorf("unable to cast %v to string for use as for kafka_id", val)
+	}
+
+	instanceAPI, _, err := api.KafkaAdmin(&ctx, kafkaID)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	val = d.Get("name")
+	name, ok := val.(string)
+	if !ok {
+		return diag.Errorf("unable to cast %v to string for use as for topic name", val)
+	}
+
+	topic, resp, err := instanceAPI.TopicsApi.GetTopic(ctx, name).Execute()
+	if err != nil {
+		apiError, err2 := utils.GetAPIError(resp, err)
+		if err2 != nil {
+			return diag.FromErr(err2)
+		}
+
+		return diag.FromErr(apiError)
+	}
+
+	err = setResourceDataFromTopic(d, &topic)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return diags
+}


### PR DESCRIPTION
This PR adds the data source for a Kafka topic which is retrieved through the Kafka id and the topic name.

## Verify
Make sure to delete any existing terraform-generated files in the directory of your config file. 

- Use the folllowing terraform config
```
terraform {
  required_providers {
    rhoas = {
      source  = "registry.terraform.io/redhat-developer/rhoas"
      version = "0.1.0"
    }
  }
}

provider "rhoas" {
    offline_token = "..."
}

resource "rhoas_kafka" "instance" {
    name = "instance"
}

resource "rhoas_topic" "topic" {
  name = "topic"
  partitions = 1
  kafka_id = rhoas_kafka.instance.id
}

data "rhoas_topic" "datasource" {
    name = rhoas_topic.topic.name
    kafka_id = rhoas_kafka.instance.id
}
```
- `make install`
- `terraform init`
- `terraform apply`
- You should have a new kafka instance
- You should have a new topic in the kafka instance
- You should have a success message like 
```
data.rhoas_topic.datasource: Reading...
data.rhoas_topic.datasource: Read complete after 1s
```
