### PR TITLE
feat: added LOCAL_DEV env variable for api mock development

### DIFF
--- a/rhoas/provider.go
+++ b/rhoas/provider.go
@@ -3,6 +3,7 @@ package rhoas
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -93,10 +94,13 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		os.Exit(1)
 	}
 
-	// nolint: contextcheck
-	httpClient := authAPI.BuildAuthenticatedHTTPClient(d.Get("offline_token").(string))
-
 	localDevelopmentServer := os.Getenv(LocalDevelopmentEnv)
+
+	httpClient := &http.Client{}
+	if localDevelopmentServer == "" {
+		// nolint: contextcheck
+		httpClient = authAPI.BuildAuthenticatedHTTPClient(d.Get("offline_token").(string))
+	}
 
 	kafkaClient := kafkamgmt.NewAPIClient(&kafkamgmt.Config{
 		HTTPClient: httpClient,

--- a/rhoas/provider_test.go
+++ b/rhoas/provider_test.go
@@ -2,6 +2,7 @@ package rhoas_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -19,6 +20,15 @@ func TestProviderIsValid(t *testing.T) {
 
 // TestProviderConfigure checks that the RHOAS client is created
 func TestProviderConfigure(t *testing.T) {
+	diag := rhoas.Provider().Configure(context.TODO(), &terraform.ResourceConfig{})
+	assert.Empty(t, diag, "got unexpected diagnostics")
+}
+
+// TestProviderConfigureLocalServer checks that the RHOAS provider can be configured to work with a local server
+func TestProviderConfigureLocalServer(t *testing.T) {
+	os.Setenv(rhoas.LocalDevelopmentEnv, "http://localhost:8000")
+	defer os.Setenv(rhoas.LocalDevelopmentEnv, "")
+
 	diag := rhoas.Provider().Configure(context.TODO(), &terraform.ResourceConfig{})
 	assert.Empty(t, diag, "got unexpected diagnostics")
 }


### PR DESCRIPTION
## Description
This pr adds functionality for the provider to use the local mock server found [here](https://github.com/redhat-developer/app-services-sdk-js/tree/main/packages/api-mock). This means when calling on the API to provision resources for us it goes trough the mock API and not the real one.

## Verify
### Terraform config (main.tf)
```
terraform {
  required_providers {
    rhoas = {
      source  = "registry.terraform.io/redhat-developer/rhoas"
      version = "0.1.0"
    }
  }
}

provider "rhoas" {
    offline_token = "..."
}

resource "rhoas_kafka" "instance" {
  name = "instance"
}
```
### Commands
- Clone [app-services-sdk-js](https://github.com/redhat-developer/app-services-sdk-js) and start mock server with these steps -> [here](https://github.com/redhat-developer/app-services-sdk-js/tree/main/packages/api-mock#local-development)
- `make clean`
- `make install`
- `LOCAL_DEV=http://localhost:8000 terraform init`
- `LOCAL_DEV=http://localhost:8000 terraform apply`

### Expected Results
You should receive a success message saying the kafka was created