### PR TITLE
feat: added more options to kafka resource

### DIFF
--- a/.cases/all_actions.md
+++ b/.cases/all_actions.md
@@ -20,6 +20,8 @@ resource "rhoas_service_account" "srvcaccnt" {
 
 resource "rhoas_kafka" "instance" {
   name = "instance"
+  plan = "developer.x1"
+  billing_model = "standard"
   acl = [
     {
       principal = rhoas_service_account.srvcaccnt.client_id,

--- a/.cases/kafka_create.md
+++ b/.cases/kafka_create.md
@@ -5,7 +5,7 @@
 ## Cases
 
 ### Missing required fields
-The fields `cloud_provider` and `region` are not defined and do not have default values.
+The fields `plan` and `billing_model` are not defined and do not have default values.
 ```
 resource "rhoas_kafka" "instance" {
   name = "my-instance"
@@ -14,21 +14,21 @@ resource "rhoas_kafka" "instance" {
 
 ### Entering computed fields 
 The fields `owner` and `id` are computed by the provider and are not allowed to be defined in the terraform config.
-```json
+```
 resource "rhoas_kafka" "instance" {
   name = "my-instance"
-  cloud_provider = "aws"
-  region = "us-east-1"
+  plan = "developer.x1"
+  billing_model = "standard"
   owner = "my-username"
   id = "1234567890"
 }
 ```
 
 ### Kafka creation success
-```json
+```
 resource "rhoas_kafka" "instance" {
   name = "my-instance"
-  cloud_provider = "aws"
-  region = "us-east-1"
+  plan = "developer.x1"
+  billing_model = "standard"
 }
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,8 @@ provider "rhoas" {}
 
 resource "rhoas_kafka" "foo" {
   name = "foo"
+  plan = "developer.x1"
+  billing_model = "standard"
 }
 
 output "bootstrap_server_foo" {

--- a/docs/resources/kafka.md
+++ b/docs/resources/kafka.md
@@ -26,6 +26,8 @@ provider "rhoas" {}
 
 resource "rhoas_kafka" "foo" {
   name = "foo"
+  plan = "developer.x1"
+  billing_model = "standard"
 }
 
 output "bootstrap_server_foo" {
@@ -38,12 +40,17 @@ output "bootstrap_server_foo" {
 
 ### Required
 
+- `billing_model` (String) Billing model for the Kafka instance
 - `name` (String) The name of the Kafka instance
+- `plan` (String) Plan for the kafka instance
 
 ### Optional
 
 - `acl` (List of Map of String) The ACL binding configuration for the kafka instance
+- `billing_cloud_account_id` (String) Billing cloud account id for the Kafka instance
 - `cloud_provider` (String) The cloud provider to use. A list of available cloud providers can be obtained using `data.rhoas_cloud_providers`
+- `marketplace` (String) The marketplace for the kafka instance
+- `reauthentication_enabled` (Boolean) Enable reauthentication for kafka instance
 - `region` (String) The region to use. A list of available regions can be obtained using `data.rhoas_cloud_providers_regions`
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/examples/resources/rhoas_kafka/resource.tf
+++ b/examples/resources/rhoas_kafka/resource.tf
@@ -11,6 +11,8 @@ provider "rhoas" {}
 
 resource "rhoas_kafka" "foo" {
   name = "foo"
+  plan = "developer.x1"
+  billing_model = "standard"
 }
 
 output "bootstrap_server_foo" {

--- a/rhoas/localize/locales/en/kafka.en.toml
+++ b/rhoas/localize/locales/en/kafka.en.toml
@@ -4,14 +4,29 @@ one = 'there was a problem getting the acl defined in the kafka instance'
 [kafka.errors.noAclFieldGiven]
 one = 'the field "{{.Field}}" was not provided in the ACL configuration of the kafka instance'
 
+[kafka.resource.field.description.name]
+one = 'The name of the Kafka instance'
+
 [kafka.resource.field.description.cloudProvider]
 one = 'The cloud provider to use. A list of available cloud providers can be obtained using `data.rhoas_cloud_providers`'
 
 [kafka.resource.field.description.region]
 one = 'The region to use. A list of available regions can be obtained using `data.rhoas_cloud_providers_regions`'
 
-[kafka.resource.field.description.name]
-one = 'The name of the Kafka instance'
+[kafka.resource.field.description.reauthenticationEnabled]
+one = 'Enable reauthentication for kafka instance'
+
+[kafka.resource.field.description.plan]
+one = 'Plan for the kafka instance'
+
+[kafka.resource.field.description.billingCloudAccountId]
+one = 'Billing cloud account id for the Kafka instance'
+
+[kafka.resource.field.description.marketplace]
+one = 'The marketplace for the kafka instance'
+
+[kafka.resource.field.description.billingModel]
+one = 'Billing model for the Kafka instance'
 
 [kafka.resource.field.description.href]
 one = 'The path to the Kafka instance in the REST API'


### PR DESCRIPTION
## Description
This pr adds more fields to the kafka resource, some are optional and some are required like plan. This means the terraform provider and our ansible have matching inputs for kafkas.

## Verify
### Terraform config (main.tf)
```
terraform {
  required_providers {
    rhoas = {
      source  = "registry.terraform.io/redhat-developer/rhoas"
      version = "0.1.0"
    }
  }
}

provider "rhoas" {
    offline_token = "..."
}

resource "rhoas_kafka" "instance" {
  name = "instance"
  plan = "developer.x1"
  billing_model = "standard"
}
```
### Commands
- `make clean`
- `make install`
- `terraform init`
- `terraform apply`

### Expected Results
A new kafka instance called `instance` 