### PR TITLE
fix: removed some options from provider that are not there

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -43,9 +43,6 @@ output "bootstrap_server_foo" {
 
 ### Optional
 
-- `api_url` (String) URL to the RHOAS services API. By default using production API (https://api.openshift.com).
-- `auth_url` (String) The auth url is used to get an access token for the service by passing the offline token. By default production is used (https://sso.redhat.com/auth/realms/redhat-external).
-- `client_id` (String) The client id is used to when getting the access token using the offline token. By default cloud-services is used.
 - `offline_token` (String) The offline token is a refresh token with no expiry and can be used by non-interactive processes to provide an access token for Red Hat OpenShift Application Services. The offline token can be obtained from [https://cloud.redhat.com/openshift/token](https://cloud.redhat.com/openshift/token). As the offline token is a sensitive value that varies between environments it is best specified using the `OFFLINE_TOKEN` environment variable.
 
 ## Source code

--- a/rhoas/provider.go
+++ b/rhoas/provider.go
@@ -2,7 +2,6 @@ package rhoas
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 
@@ -45,24 +44,6 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("OFFLINE_TOKEN", nil),
 				Description: "The offline token is a refresh token with no expiry and can be used by non-interactive processes to provide an access token for Red Hat OpenShift Application Services. The offline token can be obtained from [https://cloud.redhat.com/openshift/token](https://cloud.redhat.com/openshift/token). As the offline token is a sensitive value that varies between environments it is best specified using the `OFFLINE_TOKEN` environment variable.",
-			},
-			"auth_url": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("AUTH_URL", authAPI.DefaultAuthURL),
-				Description: fmt.Sprintf("The auth url is used to get an access token for the service by passing the offline token. By default production is used (%s).", authAPI.DefaultAuthURL),
-			},
-			"client_id": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CLIENT_ID", authAPI.DefaultClientID),
-				Description: fmt.Sprintf("The client id is used to when getting the access token using the offline token. By default %s is used.", authAPI.DefaultClientID),
-			},
-			"api_url": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("API_URL", DefaultAPIURL),
-				Description: fmt.Sprintf("URL to the RHOAS services API. By default using production API (%s).", DefaultAPIURL),
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/rhoas/provider_test.go
+++ b/rhoas/provider_test.go
@@ -60,8 +60,5 @@ func TestProviderSchema(t *testing.T) {
 	t.Run("attributes", func(t *testing.T) {
 		sut := providerSchema.Provider.Attributes
 		assert.Contains(t, sut, "offline_token")
-		assert.Contains(t, sut, "auth_url")
-		assert.Contains(t, sut, "client_id")
-		assert.Contains(t, sut, "api_url")
 	})
 }


### PR DESCRIPTION
## Verify
### Terraform config (main.tf)
```
terraform {
  required_providers {
    rhoas = {
      source  = "registry.terraform.io/redhat-developer/rhoas"
      version = "0.1.0"
    }
  }
}

provider "rhoas" {
    offline_token = "..."
}
```
### Commands
- `make clean`
- `make install`
- `terraform init`
- `terraform apply`

### Expected Results
