### PR TITLE
Better api errors

### DIFF
--- a/rhoas/acl/resource_acl.go
+++ b/rhoas/acl/resource_acl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	kafkainstanceclient "github.com/redhat-developer/app-services-sdk-go/kafkainstance/apiv1/client"
 	"github.com/redhat-developer/terraform-provider-rhoas/rhoas/localize"
+	"github.com/redhat-developer/terraform-provider-rhoas/rhoas/utils"
 	"math/rand"
 	"strconv"
 	"time"
@@ -117,9 +118,9 @@ func aclCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.
 		return diag.FromErr(err)
 	}
 
-	_, err = instanceAPI.AclsApi.CreateAcl(ctx).AclBinding(*binding).Execute()
-	if err != nil {
-		return diag.FromErr(err)
+	resp, err := instanceAPI.AclsApi.CreateAcl(ctx).AclBinding(*binding).Execute()
+	if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
+		return diag.FromErr(apiErr)
 	}
 
 	// acls have no id so we need to create a new random one for it

--- a/rhoas/cloudproviders/datasource_cloud_providers.go
+++ b/rhoas/cloudproviders/datasource_cloud_providers.go
@@ -61,7 +61,7 @@ func dataSourceCloudProvidersRead(ctx context.Context, d *schema.ResourceData, m
 
 	data, resp, err := factory.KafkaMgmt().GetCloudProviders(ctx).Execute()
 	if err != nil {
-		if apiErr := utils.GetAPIError(resp, err); apiErr != nil {
+		if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
 			return diag.FromErr(apiErr)
 		}
 	}

--- a/rhoas/cloudproviders/datasource_cloud_providers_regions.go
+++ b/rhoas/cloudproviders/datasource_cloud_providers_regions.go
@@ -67,10 +67,8 @@ func dataSourceCloudProviderRegionsRead(ctx context.Context, d *schema.ResourceD
 	}
 
 	data, resp, err := factory.KafkaMgmt().GetCloudProviderRegions(ctx, id).Execute()
-	if err != nil {
-		if apiErr := utils.GetAPIError(resp, err); apiErr != nil {
-			return diag.FromErr(apiErr)
-		}
+	if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
+		return diag.FromErr(apiErr)
 	}
 
 	if err := d.Set("regions", flattenRegions(data.Items)); err != nil {

--- a/rhoas/factory/default_factory.go
+++ b/rhoas/factory/default_factory.go
@@ -52,6 +52,7 @@ func (f *DefaultFactory) ServiceAccountMgmt() serviceAccounts.ServiceAccountsApi
 func (f *DefaultFactory) KafkaAdmin(ctx *context.Context, instanceID string) (*kafkainstanceclient.APIClient, *kafkamgmtclient.KafkaRequest, error) {
 	kafkaAPI := f.KafkaMgmt()
 
+	//nolint
 	kafkaInstance, resp, err := kafkaAPI.GetKafkaById(*ctx, instanceID).Execute()
 	if apiErr := utils.GetAPIError(f, resp, err); apiErr != nil {
 		return nil, nil, apiErr

--- a/rhoas/factory/default_factory.go
+++ b/rhoas/factory/default_factory.go
@@ -9,6 +9,7 @@ import (
 	kafkamgmtv1errors "github.com/redhat-developer/app-services-sdk-go/kafkamgmt/apiv1/error"
 	serviceAccounts "github.com/redhat-developer/app-services-sdk-go/serviceaccountmgmt/apiv1/client"
 	"github.com/redhat-developer/terraform-provider-rhoas/rhoas/localize"
+	"github.com/redhat-developer/terraform-provider-rhoas/rhoas/utils"
 	"net/http"
 )
 
@@ -52,8 +53,8 @@ func (f *DefaultFactory) KafkaAdmin(ctx *context.Context, instanceID string) (*k
 	kafkaAPI := f.KafkaMgmt()
 
 	kafkaInstance, resp, err := kafkaAPI.GetKafkaById(*ctx, instanceID).Execute()
-	if resp != nil {
-		defer resp.Body.Close()
+	if apiErr := utils.GetAPIError(f, resp, err); apiErr != nil {
+		return nil, nil, apiErr
 	}
 
 	if kafkamgmtv1errors.IsAPIError(err, kafkamgmtv1errors.ERROR_7) {

--- a/rhoas/kafka/datasource_kafka.go
+++ b/rhoas/kafka/datasource_kafka.go
@@ -94,10 +94,8 @@ func dataSourceKafkaRead(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	kafka, resp, err := factory.KafkaMgmt().GetKafkaById(ctx, id).Execute()
-	if err != nil {
-		if apiErr := utils.GetAPIError(resp, err); apiErr != nil {
-			return diag.FromErr(apiErr)
-		}
+	if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
+		return diag.FromErr(apiErr)
 	}
 
 	err = setResourceDataFromKafkaData(d, &kafka)

--- a/rhoas/kafka/datasource_kafkas.go
+++ b/rhoas/kafka/datasource_kafkas.go
@@ -113,10 +113,8 @@ func dataSourceKafkasRead(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 
 	kafkas, resp, err := factory.KafkaMgmt().GetKafkas(ctx).Execute()
-	if err != nil {
-		if apiErr := utils.GetAPIError(resp, err); apiErr != nil {
-			return diag.FromErr(apiErr)
-		}
+	if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
+		return diag.FromErr(apiErr)
 	}
 
 	if err := d.Set("kafkas", flattenKafkas(kafkas.Items)); err != nil {

--- a/rhoas/localize/locales/en/common.en.toml
+++ b/rhoas/localize/locales/en/common.en.toml
@@ -1,2 +1,23 @@
 [common.errors.fieldNotFoundInSchema]
 one = 'the field "{{.Field}}" could not be found in the schema resource'
+
+[common.errors.api.badRequest]
+one = 'The client request was invalid. One or more request parameters or the request body was rejected'
+
+[common.errors.api.unauthorized]
+one = 'Request authentication missing or invalid'
+
+[common.errors.api.forbidden]
+one = 'User is not authorized to access requested resource or service'
+
+[common.errors.api.internalServerError]
+one = 'Internal server error'
+
+[common.errors.api.serviceUnavailable]
+one = 'Service unavailable'
+
+[common.errors.api.conflict]
+one = 'The resource already exists'
+
+[common.errors.api.notFound]
+one = 'The requested resource or service could not be found'

--- a/rhoas/serviceaccount/datasource_serviceaccount.go
+++ b/rhoas/serviceaccount/datasource_serviceaccount.go
@@ -63,10 +63,8 @@ func dataSourceServiceAccountRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	serviceAccount, resp, err := factory.ServiceAccountMgmt().GetServiceAccount(ctx, id).Execute()
-	if err != nil {
-		if apiErr := utils.GetAPIError(resp, err); apiErr != nil {
-			return diag.FromErr(apiErr)
-		}
+	if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
+		return diag.FromErr(apiErr)
 	}
 
 	err = setResourceDataFromServiceAccountData(d, &serviceAccount)

--- a/rhoas/serviceaccount/datasource_serviceaccounts.go
+++ b/rhoas/serviceaccount/datasource_serviceaccounts.go
@@ -2,8 +2,7 @@ package serviceaccount
 
 import (
 	"context"
-	"io"
-	"log"
+	"github.com/redhat-developer/terraform-provider-rhoas/rhoas/utils"
 	"strconv"
 	"time"
 
@@ -73,12 +72,8 @@ func dataSourceKafkasRead(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 
 	data, resp, err := factory.ServiceAccountMgmt().GetServiceAccounts(ctx).Execute()
-	if err != nil {
-		bodyBytes, ioErr := io.ReadAll(resp.Body)
-		if ioErr != nil {
-			log.Fatal(ioErr)
-		}
-		return diag.Errorf("%s%s", err.Error(), string(bodyBytes))
+	if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
+		return diag.FromErr(apiErr)
 	}
 
 	if err := d.Set("service_accounts", flattenServiceAccountData(data)); err != nil {

--- a/rhoas/serviceaccount/resource_serviceaccount.go
+++ b/rhoas/serviceaccount/resource_serviceaccount.go
@@ -91,10 +91,8 @@ func serviceAccountDelete(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 
 	resp, err := factory.ServiceAccountMgmt().DeleteServiceAccount(ctx, id).Execute()
-	if err != nil {
-		if apiErr := utils.GetAPIError(resp, err); apiErr != nil {
-			return diag.FromErr(apiErr)
-		}
+	if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
+		return diag.FromErr(apiErr)
 	}
 
 	d.SetId("")
@@ -114,7 +112,7 @@ func serviceAccountRead(ctx context.Context, d *schema.ResourceData, m interface
 	// service account is created
 	serviceAccount, resp, err := factory.ServiceAccountMgmt().GetServiceAccount(ctx, d.Id()).Execute()
 	if err != nil {
-		if apiErr := utils.GetAPIError(resp, err); apiErr != nil {
+		if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
 			return diag.FromErr(apiErr)
 		}
 	}
@@ -143,7 +141,7 @@ func serviceAccountCreate(ctx context.Context, d *schema.ResourceData, m interfa
 
 	serviceAccount, resp, err := factory.ServiceAccountMgmt().CreateServiceAccount(ctx).ServiceAccountCreateRequestData(*request).Execute()
 	if err != nil {
-		if apiErr := utils.GetAPIError(resp, err); apiErr != nil {
+		if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
 			return diag.FromErr(apiErr)
 		}
 	}

--- a/rhoas/tests/kafka_test.go
+++ b/rhoas/tests/kafka_test.go
@@ -112,7 +112,7 @@ func TestAccRHOASKafka_Error(t *testing.T) {
 // testAccCheckKafkaDestroy verifies the Kafka cluster has been destroyed
 func testAccCheckKafkaDestroy(s *terraform.State) error {
 	// retrieve the connection established in Provider configuration
-	api, ok := testAccRHOAS.Meta().(rhoasAPI.Factory)
+	factory, ok := testAccRHOAS.Meta().(rhoasAPI.Factory)
 	if !ok {
 		return errors.Errorf("unable to cast %v to rhoasAPI.Factory)", testAccRHOAS.Meta())
 	}
@@ -124,14 +124,9 @@ func testAccCheckKafkaDestroy(s *terraform.State) error {
 		}
 
 		// Retrieve the kafka struct by referencing it's state ID for API lookup
-		kafka, resp, err := api.KafkaMgmt().GetKafkaById(context.Background(), rs.Primary.ID).Execute()
-		if err != nil {
-			if err.Error() == "404 Not Found" {
-				return nil
-			}
-			if apiErr := utils.GetAPIError(resp, err); apiErr != nil {
-				return apiErr
-			}
+		kafka, resp, err := factory.KafkaMgmt().GetKafkaById(context.Background(), rs.Primary.ID).Execute()
+		if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
+			return apiErr
 		}
 
 		return errors.Errorf("expected a 404 but found a kafka instance: %v", kafka)
@@ -150,13 +145,13 @@ func testAccCheckKafkaExists(resource string, kafka *kafkamgmtclient.KafkaReques
 			return fmt.Errorf("No Record ID is set")
 		}
 
-		api, ok := testAccRHOAS.Meta().(rhoasAPI.Factory)
+		factory, ok := testAccRHOAS.Meta().(rhoasAPI.Factory)
 		if !ok {
 			return errors.Errorf("unable to cast %v to rhoasAPI.Factory)", testAccRHOAS.Meta())
 		}
-		gotKafka, resp, err := api.KafkaMgmt().GetKafkaById(context.Background(), rs.Primary.ID).Execute()
+		gotKafka, resp, err := factory.KafkaMgmt().GetKafkaById(context.Background(), rs.Primary.ID).Execute()
 		if err != nil {
-			if apiErr := utils.GetAPIError(resp, err); apiErr != nil {
+			if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
 				return apiErr
 			}
 		}

--- a/rhoas/topic/datasource_topic.go
+++ b/rhoas/topic/datasource_topic.go
@@ -58,11 +58,8 @@ func dataSourceTopicRead(ctx context.Context, d *schema.ResourceData, m interfac
 	}
 
 	topic, resp, err := instanceAPI.TopicsApi.GetTopic(ctx, name).Execute()
-	if err != nil {
-		err2 := utils.GetAPIError(resp, err)
-		if err2 != nil {
-			return diag.FromErr(err2)
-		}
+	if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
+		return diag.FromErr(apiErr)
 	}
 
 	err = setResourceDataFromTopic(d, &topic)

--- a/rhoas/topic/resource_topic.go
+++ b/rhoas/topic/resource_topic.go
@@ -76,10 +76,8 @@ func topicDelete(ctx context.Context, d *schema.ResourceData, m interface{}) dia
 	}
 
 	resp, err := instanceAPI.TopicsApi.DeleteTopic(ctx, topicName).Execute()
-	if err != nil {
-		if apiErr := utils.GetAPIError(resp, err); apiErr != nil {
-			return diag.FromErr(apiErr)
-		}
+	if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
+		return diag.FromErr(apiErr)
 	}
 
 	d.SetId("")
@@ -111,10 +109,8 @@ func topicRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.
 	}
 
 	topic, resp, err := instanceAPI.TopicsApi.GetTopic(ctx, topicName).Execute()
-	if err != nil {
-		if apiErr := utils.GetAPIError(resp, err); apiErr != nil {
-			return diag.FromErr(apiErr)
-		}
+	if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
+		return diag.FromErr(apiErr)
 	}
 
 	err = setResourceDataFromTopic(d, &topic)
@@ -152,10 +148,8 @@ func topicCreate(ctx context.Context, d *schema.ResourceData, m interface{}) dia
 	}
 
 	topic, resp, err := topicRequest.Execute()
-	if err != nil {
-		if apiErr := utils.GetAPIError(resp, err); apiErr != nil {
-			return diag.FromErr(apiErr)
-		}
+	if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
+		return diag.FromErr(apiErr)
 	}
 
 	err = setResourceDataFromTopic(d, &topic)

--- a/rhoas/utils/api.go
+++ b/rhoas/utils/api.go
@@ -41,27 +41,32 @@ func GetAPIError(factory rhoasAPI.Factory, response *http.Response, apiError err
 	// this to support terraform acceptance tests which make it impossible to pass factory around
 	// testing code should never affect actual code but no one actually about make good software
 	if factory == nil {
+		//nolint
 		return fmt.Errorf("%v : %v", parseResponse(response).Error(), apiError.Error())
 	}
 
 	switch response.StatusCode {
 	case http.StatusBadRequest:
-		return fmt.Errorf("%v : %v", factory.Localizer().MustLocalize("common.errors.api.badRequest"), apiError.Error())
+		return fmt.Errorf(buildErrorString(factory.Localizer().MustLocalize("common.errors.api.badRequest"), response, apiError))
 	case http.StatusUnauthorized:
-		return fmt.Errorf("%v : %v", factory.Localizer().MustLocalize("common.errors.api.unauthorized"), apiError.Error())
+		return fmt.Errorf(buildErrorString(factory.Localizer().MustLocalize("common.errors.api.unauthorized"), response, apiError))
 	case http.StatusForbidden:
-		return fmt.Errorf("%v : %v", factory.Localizer().MustLocalize("common.errors.api.forbidden"), apiError.Error())
+		return fmt.Errorf(buildErrorString(factory.Localizer().MustLocalize("common.errors.api.forbidden"), response, apiError))
 	case http.StatusInternalServerError:
-		return fmt.Errorf("%v : %v", factory.Localizer().MustLocalize("common.errors.api.internalServerError"), apiError.Error())
+		return fmt.Errorf(buildErrorString(factory.Localizer().MustLocalize("common.errors.api.internalServerError"), response, apiError))
 	case http.StatusServiceUnavailable:
-		return fmt.Errorf("%v : %v", factory.Localizer().MustLocalize("common.errors.api.serviceUnavailable"), apiError.Error())
+		return fmt.Errorf(buildErrorString(factory.Localizer().MustLocalize("common.errors.api.serviceUnavailable"), response, apiError))
 	case http.StatusConflict:
-		return fmt.Errorf("%v : %v", factory.Localizer().MustLocalize("common.errors.api.conflict"), apiError.Error())
+		return fmt.Errorf(buildErrorString(factory.Localizer().MustLocalize("common.errors.api.conflict"), response, apiError))
 	case http.StatusNotFound:
-		return fmt.Errorf("%v : %v", factory.Localizer().MustLocalize("common.errors.api.notFound"), apiError.Error())
+		return fmt.Errorf(buildErrorString(factory.Localizer().MustLocalize("common.errors.api.notFound"), response, apiError))
 	}
 
 	return apiError
+}
+
+func buildErrorString(message string, response *http.Response, apiError error) string {
+	return fmt.Sprintf("%v :: %v :: %v :: %v", message, apiError.Error(), response.Request.URL.Host+response.Request.URL.Path, response.Request.Method)
 }
 
 func parseResponse(response *http.Response) error {

--- a/rhoas/utils/api_test.go
+++ b/rhoas/utils/api_test.go
@@ -57,14 +57,3 @@ func TestGetAPIError(t *testing.T) {
 		assert.Equal(t, testAPIError, err, "GetAPIError should return the same error passed in")
 	})
 }
-
-type erroringBuffer struct {
-}
-
-func (mb erroringBuffer) Close() error {
-	return nil
-}
-
-func (mb erroringBuffer) Read(p []byte) (n int, err error) {
-	return 0, errors.New("error reading body")
-}


### PR DESCRIPTION
# Description
This pr adds more detailed error messages to the provider, before we just returned the status code from the api but now we give the description, erorr code, URL and method.

## Verify
### Terraform config (main.tf)
```
terraform {
  required_providers {
    rhoas = {
      source  = "registry.terraform.io/redhat-developer/rhoas"
      version = "0.1.0"
    }
  }
}

provider "rhoas" {
    offline_token = "..."
}

resource "rhoas_kafka" "instance" {
  name = "instance"
  plan = "developer.x1"
  billing_model = "standard"
}
```
### Commands
- `make clean`
- `make install`
- `terraform init`
- `terraform apply`
- ... wait for kafka to create
- `make clean`
- `make install`
- `terraform init`
- `terraform apply`

### Expected Results
A descriptive error message saying that creating the kafka cannot be done as it already exists 
```
│ Error: The resource already exists :: 409 Conflict :: api.openshift.com/api/kafkas_mgmt/v1/kafkas :: POST
│
│   with rhoas_kafka.instance,
│   on main.tf line 18, in resource "rhoas_kafka" "instance":
│   18: resource "rhoas_kafka" "instance" {
```
