### PR TITLE
fix: kafka config in tests now have all fields

### DIFF
--- a/rhoas/tests/kafka_test.go
+++ b/rhoas/tests/kafka_test.go
@@ -17,8 +17,10 @@ import (
 )
 
 const (
-	kafkaID   = "test_kafka"
-	kafkaPath = "rhoas_kafka.test_kafka"
+	kafkaID           = "test_kafka"
+	kafkaPath         = "rhoas_kafka.test_kafka"
+	PlanInput         = "developer.x1"
+	BillingModelInput = "standard"
 )
 
 // TestAccRHOASKafka_Basic checks that this provider is able to spin up a
@@ -187,8 +189,10 @@ func testAccKafkaBasic(id, name string) string {
 	return fmt.Sprintf(`
 resource "rhoas_kafka" "%s" {
   name = "%s"
+  plan = "%s"
+  billing_model = "%s"
 }
-`, id, name)
+`, id, name, PlanInput, BillingModelInput)
 }
 
 func testAccKafkaWithCloudProvider(id, name, cloudProvider string) string {
@@ -196,17 +200,21 @@ func testAccKafkaWithCloudProvider(id, name, cloudProvider string) string {
 resource "rhoas_kafka" "%s" {
   name = "%s"
   cloud_provider = "%s"
+  plan = "%s"
+  billing_model = "%s"
 }
-`, id, name, cloudProvider)
+`, id, name, cloudProvider, PlanInput, BillingModelInput)
 }
 
 func Test_testAccKafkaBasic(t *testing.T) {
 	assert.Equal(
-		t, `
+		t, fmt.Sprintf(`
 resource "rhoas_kafka" "test_id" {
   name = "test_name"
+  plan = "%s"
+  billing_model = "%s"
 }
-`,
+`, PlanInput, BillingModelInput),
 		testAccKafkaBasic("test_id", "test_name"),
 	)
 }

--- a/rhoas/tests/topics_test.go
+++ b/rhoas/tests/topics_test.go
@@ -222,6 +222,8 @@ func testAccTopicBasic(id, name string, partitions int) string {
 	return fmt.Sprintf(`
 resource "rhoas_kafka" "test_kafka_create_topic" {
   name = "%s"
+  plan = "%s"
+  billing_model = "%s"
 }
 
 resource "rhoas_topic" "%s" {
@@ -229,15 +231,17 @@ resource "rhoas_topic" "%s" {
   partitions = %d
   kafka_id   = rhoas_kafka.test_kafka_create_topic.id
 }
-`, kafkaName, id, name, partitions)
+`, kafkaName, PlanInput, BillingModelInput, id, name, partitions)
 }
 
 func testAccTopicDestroyedBasic() string {
 	return fmt.Sprintf(`
 resource "rhoas_kafka" "test_kafka_create_topic" {
   name = "%s"
+  plan = "%s"
+  billing_model = "%s"
 }
-`, kafkaName)
+`, kafkaName, PlanInput, BillingModelInput)
 }
 
 func Test_testAccTopicBasic(t *testing.T) {
@@ -245,6 +249,8 @@ func Test_testAccTopicBasic(t *testing.T) {
 		t, fmt.Sprintf(`
 resource "rhoas_kafka" "test_kafka_create_topic" {
   name = "%s"
+  plan = "%s"
+  billing_model = "%s"
 }
 
 resource "rhoas_topic" "test_id" {
@@ -252,7 +258,7 @@ resource "rhoas_topic" "test_id" {
   partitions = 1
   kafka_id   = rhoas_kafka.test_kafka_create_topic.id
 }
-`, kafkaName),
+`, kafkaName, PlanInput, BillingModelInput),
 		testAccTopicBasic("test_id", "test-name", 1),
 	)
 }


### PR DESCRIPTION
## Verify
### Terraform config (main.tf)
```
terraform {
  required_providers {
    rhoas = {
      source  = "registry.terraform.io/redhat-developer/rhoas"
      version = "0.1.0"
    }
  }
}

provider "rhoas" {
    offline_token = "..."
}
```
### Commands
- `make clean`
- `make install`
- `terraform init`
- `terraform apply`

### Expected Results
