### PR TITLE
fix: added missing fields in kafka datasource

### DIFF
--- a/rhoas/kafka/datasource_kafka.go
+++ b/rhoas/kafka/datasource_kafka.go
@@ -15,6 +15,11 @@ func DataSourceKafka(localizer localize.Localizer) *schema.Resource {
 		Description: "`rhoas_kafka` provides a Kafka accessible to your organization in Red Hat OpenShift Streams for Apache Kafka.",
 		ReadContext: dataSourceKafkaRead,
 		Schema: map[string]*schema.Schema{
+			NameField: {
+				Description: localizer.MustLocalize("kafka.resource.field.description.name"),
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 			CloudProviderField: {
 				Description: localizer.MustLocalize("kafka.resource.field.description.cloudProvider"),
 				Type:        schema.TypeString,
@@ -25,8 +30,28 @@ func DataSourceKafka(localizer localize.Localizer) *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
-			NameField: {
-				Description: localizer.MustLocalize("kafka.resource.field.description.name"),
+			ReauthenticationEnabledField: {
+				Description: localizer.MustLocalize("kafka.resource.field.description.reauthenticationEnabled"),
+				Type:        schema.TypeBool,
+				Computed:    true,
+			},
+			PlanField: {
+				Description: localizer.MustLocalize("kafka.resource.field.description.plan"),
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			BillingCloudAccountIDField: {
+				Description: localizer.MustLocalize("kafka.resource.field.description.billingCloudAccountId"),
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			MarketPlaceField: {
+				Description: localizer.MustLocalize("kafka.resource.field.description.marketplace"),
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			BillingModelField: {
+				Description: localizer.MustLocalize("kafka.resource.field.description.billingModel"),
 				Type:        schema.TypeString,
 				Computed:    true,
 			},


### PR DESCRIPTION
## Description
This pro adds fields that were missing from the kafka data source. This was causing crashes before.

## Verify
### Terraform config (main.tf)
```
terraform {
  required_providers {
    rhoas = {
      source  = "registry.terraform.io/redhat-developer/rhoas"
      version = "0.1.0"
    }
  }
}

provider "rhoas" {
    offline_token = "..."
}


resource "rhoas_kafka" "instance" {
  name = "instance"
  plan = "developer.x1"
  billing_model = "standard"
}

data "rhoas_kafka" "instance_data" {
  id = rhoas_kafka.instance.id
}
```
### Commands
- `make clean`
- `make install`
- `terraform init`
- `terraform apply`

### Expected Results
All actions should be performed correctly with the new kafka being created and the data source reading the kafka resource.
