### PR TITLE
If deleting a resource gives a 404 we should be fine

### DIFF
--- a/rhoas/kafka/resource_kafka.go
+++ b/rhoas/kafka/resource_kafka.go
@@ -2,7 +2,6 @@ package kafka
 
 import (
 	"context"
-	"net/http"
 	"strings"
 	"time"
 
@@ -186,7 +185,7 @@ func kafkaDelete(ctx context.Context, d *schema.ResourceData, m interface{}) dia
 		},
 		Refresh: func() (interface{}, string, error) {
 			data, resp, err1 := factory.KafkaMgmt().GetKafkaById(ctx, d.Id()).Execute()
-			if resp.StatusCode == http.StatusNotFound {
+			if utils.CheckNotFound(resp) {
 				return data, "deleted", nil
 			}
 			if apiErr := utils.GetAPIError(factory, resp, err1); apiErr != nil {

--- a/rhoas/kafka/resource_kafka.go
+++ b/rhoas/kafka/resource_kafka.go
@@ -2,11 +2,13 @@ package kafka
 
 import (
 	"context"
+	"net/http"
+	"strings"
+	"time"
+
 	kafkainstanceclient "github.com/redhat-developer/app-services-sdk-go/kafkainstance/apiv1/client"
 	"github.com/redhat-developer/terraform-provider-rhoas/rhoas/acl"
 	"github.com/redhat-developer/terraform-provider-rhoas/rhoas/localize"
-	"strings"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -184,6 +186,9 @@ func kafkaDelete(ctx context.Context, d *schema.ResourceData, m interface{}) dia
 		},
 		Refresh: func() (interface{}, string, error) {
 			data, resp, err1 := factory.KafkaMgmt().GetKafkaById(ctx, d.Id()).Execute()
+			if resp.StatusCode == http.StatusNotFound {
+				return data, "deleted", nil
+			}
 			if apiErr := utils.GetAPIError(factory, resp, err1); apiErr != nil {
 				return nil, "", apiErr
 			}

--- a/rhoas/tests/kafka_test.go
+++ b/rhoas/tests/kafka_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 	"testing"
 
@@ -127,6 +128,9 @@ func testAccCheckKafkaDestroy(s *terraform.State) error {
 
 		// Retrieve the kafka struct by referencing it's state ID for API lookup
 		kafka, resp, err := factory.KafkaMgmt().GetKafkaById(context.Background(), rs.Primary.ID).Execute()
+		if resp.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
 			return apiErr
 		}

--- a/rhoas/tests/kafka_test.go
+++ b/rhoas/tests/kafka_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"regexp"
 	"testing"
 
@@ -128,7 +127,7 @@ func testAccCheckKafkaDestroy(s *terraform.State) error {
 
 		// Retrieve the kafka struct by referencing it's state ID for API lookup
 		kafka, resp, err := factory.KafkaMgmt().GetKafkaById(context.Background(), rs.Primary.ID).Execute()
-		if resp.StatusCode == http.StatusNotFound {
+		if utils.CheckNotFound(resp) {
 			return nil
 		}
 		if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {

--- a/rhoas/tests/serviceaccount_test.go
+++ b/rhoas/tests/serviceaccount_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"regexp"
 	"testing"
 
@@ -189,7 +188,7 @@ func testAccCheckServiceAccountDestroy(s *terraform.State) error {
 
 		// Retrieve the service account struct by referencing it's state ID for API lookup
 		serviceAccount, resp, err := factory.ServiceAccountMgmt().GetServiceAccount(context.Background(), rs.Primary.ID).Execute()
-		if resp.StatusCode == http.StatusNotFound {
+		if utils.CheckNotFound(resp) {
 			return nil
 		}
 		if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {

--- a/rhoas/tests/serviceaccount_test.go
+++ b/rhoas/tests/serviceaccount_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"regexp"
 	"testing"
 
@@ -188,6 +189,9 @@ func testAccCheckServiceAccountDestroy(s *terraform.State) error {
 
 		// Retrieve the service account struct by referencing it's state ID for API lookup
 		serviceAccount, resp, err := factory.ServiceAccountMgmt().GetServiceAccount(context.Background(), rs.Primary.ID).Execute()
+		if resp.StatusCode == http.StatusNotFound {
+			return nil
+		}
 		if apiErr := utils.GetAPIError(factory, resp, err); apiErr != nil {
 			return apiErr
 		}

--- a/rhoas/utils/api.go
+++ b/rhoas/utils/api.go
@@ -3,9 +3,10 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	rhoasAPI "github.com/redhat-developer/terraform-provider-rhoas/rhoas/api"
 	"io"
 	"net/http"
+
+	rhoasAPI "github.com/redhat-developer/terraform-provider-rhoas/rhoas/api"
 
 	"github.com/pkg/errors"
 )
@@ -80,4 +81,9 @@ func parseResponse(response *http.Response) error {
 	}
 
 	return errors.New(string(bodyBytes))
+}
+
+// CheckNotFound checks whether the response status code is not found
+func CheckNotFound(response *http.Response) bool {
+	return response.StatusCode == http.StatusNotFound
 }

--- a/rhoas/utils/api_test.go
+++ b/rhoas/utils/api_test.go
@@ -1,9 +1,11 @@
 package utils_test
 
 import (
+	"net/http"
+	"testing"
+
 	factories "github.com/redhat-developer/terraform-provider-rhoas/rhoas/factory"
 	"github.com/redhat-developer/terraform-provider-rhoas/rhoas/localize/goi18n"
-	"testing"
 
 	"github.com/pkg/errors"
 
@@ -56,4 +58,15 @@ func TestGetAPIError(t *testing.T) {
 		err := utils.GetAPIError(factory, nil, testAPIError)
 		assert.Equal(t, testAPIError, err, "GetAPIError should return the same error passed in")
 	})
+}
+
+func TestCheckNotFound(t *testing.T) {
+	var notFoundResponse = http.Response{
+		StatusCode: http.StatusNotFound,
+	}
+	var internalErrorResponse = http.Response{
+		StatusCode: http.StatusInternalServerError,
+	}
+	assert.True(t, utils.CheckNotFound(&notFoundResponse))
+	assert.False(t, utils.CheckNotFound(&internalErrorResponse))
 }


### PR DESCRIPTION
Fix some errors appearing in all the tests, f.e in [this one](https://github.com/redhat-developer/terraform-provider-rhoas/actions/runs/3338302597/jobs/5525793507#step:10:77):
```
Error: Error waiting for example instance (FztVctEr3pp1_zWNGjG-M) to be deleted: The requested resource or service could not be found :: 404 Not Found :: mock-api:8000/api/kafkas_mgmt/v1/kafkas/FztVctEr3pp1_zWNGjG-M :: GET
```

Tests are still not passing probably because of the mock server.