### PR TITLE
feat: added lint-lang to ci-cd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,17 @@ jobs:
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest
+  lint-lang:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Check i18n
+        run: make lint-lang
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir


### PR DESCRIPTION
Adds the lint lang command to the github actions list. If this fails it means there are issues with how you are using the localization in the provider.