### PR TITLE
Fix 'Error: The client request was invalid...'

### DIFF
--- a/rhoas/tests/kafka_test.go
+++ b/rhoas/tests/kafka_test.go
@@ -103,7 +103,7 @@ func TestAccRHOASKafka_Error(t *testing.T) {
 				Config: testAccKafkaWithCloudProvider(
 					kafkaID, randomName, "not-a-cloud-provider"),
 				ExpectError: regexp.MustCompile(
-					"provider not-a-cloud-provider is not supported, supported providers are:",
+					"The client request was invalid.",
 				),
 			},
 		},

--- a/rhoas/tests/serviceaccount_test.go
+++ b/rhoas/tests/serviceaccount_test.go
@@ -108,7 +108,7 @@ func TestAccRHOASServiceAccount_Error(t *testing.T) {
 				Config: testAccServiceAccountBasic(
 					serviceAccountID, ""),
 				ExpectError: regexp.MustCompile(
-					"Request failed field validation",
+					"The client request was invalid.",
 				),
 			},
 		},

--- a/rhoas/tests/topics_test.go
+++ b/rhoas/tests/topics_test.go
@@ -109,7 +109,7 @@ func TestAccRHOASTopic_Error(t *testing.T) {
 				Config: testAccTopicBasic(
 					topicID, "", topicPartitions),
 				ExpectError: regexp.MustCompile(
-					"name must not be blank",
+					"The client request was invalid.",
 				),
 			},
 		},


### PR DESCRIPTION
## Verify

Run `make testacc` with both the mocked server and the real server and see that `TestAccRHOASKafka_Error` and `TestAccRHOASServiceAccount_Error` have been fixed.

## Explanation

These failures were introduced in https://github.com/redhat-developer/terraform-provider-rhoas/commit/1a502b093ae1c121547f61e178bb11b20f921260. It was just a change in the error strings.

Fixes https://github.com/redhat-developer/terraform-provider-rhoas/issues/66 too.

