### PR TITLE
feat: can now use staging with the API env

### DIFF
--- a/rhoas/provider_test.go
+++ b/rhoas/provider_test.go
@@ -26,8 +26,8 @@ func TestProviderConfigure(t *testing.T) {
 
 // TestProviderConfigureLocalServer checks that the RHOAS provider can be configured to work with a local server
 func TestProviderConfigureLocalServer(t *testing.T) {
-	os.Setenv(rhoas.LocalDevelopmentEnv, "http://localhost:8000")
-	defer os.Setenv(rhoas.LocalDevelopmentEnv, "")
+	os.Setenv("API", "mock")
+	defer os.Setenv("API", "")
 
 	diag := rhoas.Provider().Configure(context.TODO(), &terraform.ResourceConfig{})
 	assert.Empty(t, diag, "got unexpected diagnostics")


### PR DESCRIPTION
## Verify
### Terraform config (main.tf)
```
terraform {
  required_providers {
    rhoas = {
      source  = "registry.terraform.io/redhat-developer/rhoas"
      version = "0.1.0"
    }
  }
}

provider "rhoas" {
    offline_token = "..."
}

resource "rhoas_kafka" "instance" {
  name = "my-instance"
  plan = "developer.x1"
  billing_model = "standard"
}

resource "rhoas_topic" "topic" {
  name = "topic"
  partitions = 1
  kafka_id = rhoas_kafka.instance.id
}
```
### Commands
- `make clean`
- `make install`
- `terraform init`
- `API=stage terraform apply`
- `make clean`
- `terraform init`
- `API=prod terraform apply`
- `make clean`
- `terraform init`
- `API=mock terraform apply` // have the mocker server running on its default endpoint 

### Expected Results
- Kafka is created
- Topic is created within kafka
- Working on API given